### PR TITLE
workaround for async functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = {
     "react/jsx-boolean-value": 0,
     "max-len": [2, 200],
     "no-underscore-dangle": ["error", { "allow": ["_id", "__v"] }],
+    "generator-star-spacing": 0,
   },
   parserOptions: {
     ecmaFeatures: {


### PR DESCRIPTION
Without this rule, in some environments the eslint might throw a TypeError like the following: 

Cannot read property 'value' of undefined
TypeError: Cannot read property 'value' of undefined
    at getStarToken